### PR TITLE
Fix a bug that occurs when Gradle Shadow 1.2.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@
 
 plugins {
     id "io.ratpack.ratpack-groovy" version "1.0.0"
-    id "com.github.johnrengelman.shadow" version "1.2.2"
+    id "com.github.johnrengelman.shadow" version "1.2.3"
     id "idea"
     id "eclipse"
 }


### PR DESCRIPTION
Details are below.

- [Unable to create task of type 'ShadowJar' with Gradle 2.11 rc 1 · Issue #177 · johnrengelman/shadow](https://github.com/johnrengelman/shadow/issues/177)